### PR TITLE
Inline lexer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "**/package-lock.json": true,
     "package.json.lerna_backup": true,
     "packages/**/node_modules": true,
-    "packages/**/tsconfig.json": true
+    // "packages/**/tsconfig.json": true
   },
   "editor.wordSeparators": "`~!@#%^&*()-=+[{]}\\|;:'\",.<>/?",
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/cli",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A command line interface for marklet.",
   "author": "jjyyxx <1449843302@qq.com>",
   "contributors": [
@@ -19,8 +19,8 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/dev-server": "^1.0.11",
-    "@marklet/parser": "^1.0.4",
+    "@marklet/dev-server": "^1.0.12",
+    "@marklet/parser": "^1.1.0",
     "chalk": "^2.4.1",
     "commander": "^2.18.0",
     "js-yaml": "^3.12.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@marklet/core",
-  "version": "1.0.9",
-  "description": "A lexer for marklet.",
+  "version": "2.0.0-beta.0",
+  "description": "Some core conceptions of marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [
     "jjyyxx <1449843302@qq.com>"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/core",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0",
   "description": "Some core conceptions of marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,27 +1,9 @@
-type ResultMap<T extends Record<string, (...arg: any[]) => any>> = {
-  [key in keyof T]: ReturnType<T[key]>
-}
+export type StringLike = string | RegExp
 
-type StringLike = string | RegExp
-type Capture = RegExpExecArray & ResultMap<GetterFunctionMap>
-type GetterFunction = (this: Lexer, capture: RegExpExecArray) => any
-type GetterFunctionMap = Record<string, GetterFunction>
-export interface LexerConfig { [key: string]: any }
-export interface LexerOptions {
-  /** lexer capture getters */
-  getters?: GetterFunctionMap
-  /** lexer rule regex macros */
-  macros?: Record<string, StringLike>
-  /** entrance context */
-  entrance?: string
-  /** default context */
-  default?: string
-  /** assign start/end to tokens */
-  requireBound?: boolean
-  /** other configurations */
-  config?: LexerConfig
-}
+export type LexerConfig = Record<string, any>
+export type LexerMacros = Record<string, StringLike>
 
+export type TokenLike = string | LexerToken
 export interface LexerToken {
   type?: string
   text?: string
@@ -31,9 +13,18 @@ export interface LexerToken {
   [key: string]: any
 }
 
-export type TokenLike = string | LexerToken
-interface LexerIncludeRule { include: string }
-interface LexerRegexRule<S extends StringLike> {
+export type LexerRule<
+  S extends StringLike = RegExp,
+  T extends LexerClass = LexerClass,
+  R extends RegExpExecArray = RegExpExecArray,
+> = LexerIncludeRule | LexerRegexRule<S, T, R>
+
+export interface LexerIncludeRule { include: string }
+export interface LexerRegexRule<
+  S extends StringLike = StringLike,
+  T extends LexerClass = LexerClass,
+  R extends RegExpExecArray = RegExpExecArray,
+> {
   /** the regular expression to execute */
   regex?: S
   /**
@@ -48,15 +39,13 @@ interface LexerRegexRule<S extends StringLike> {
   /** default type of the token */
   type?: string
   /** whether the rule is to be executed */
-  test?: string | boolean | ((config: LexerConfig) => boolean)
+  test?: string | boolean | ((this: T, config: LexerConfig) => boolean)
   /** a result token */
   token?: TokenLike | TokenLike[] | ((
-    this: Lexer, capture: Capture, content: TokenLike[], rule: this
+    this: T, capture: R, content: TokenLike[]
   ) => TokenLike | TokenLike[])
   /** the inner context */
-  push?: string | LexerRule<S>[] | ((
-    this: Lexer, capture: Capture
-  ) => string | LexerRule<S>[] | false)
+  push?: string | LexerRule<S>[]
   /** pop from the current context */
   pop?: boolean
   /** match when the context begins */
@@ -69,221 +58,48 @@ interface LexerRegexRule<S extends StringLike> {
   eol?: boolean
 }
 
-interface LexerWarning {
-  message: string
-}
-
-type LexerContext = string | NativeLexerRule[]
-type LexerRule<S extends StringLike> = LexerRegexRule<S> | LexerIncludeRule
-type LooseLexerRule = LexerRule<StringLike>
-type NativeLexerRule = LexerRule<RegExp>
-export type LexerRules = Record<string, LooseLexerRule[]>
-
-function getString(string: StringLike): string {
+/** Transform a string-like object into a raw string. */
+export function getString(string: StringLike): string {
   return string instanceof RegExp ? string.source : string
 }
 
-export class Lexer {
+export function parseRule(rule: LexerRule<StringLike>, macros: LexerMacros = {}): LexerRule {
+  if (!('include' in rule)) {
+    if (rule.regex === undefined) {
+      rule.regex = /(?=[\s\S])/
+      if (!rule.type) rule.type = 'default'
+    }
+    if (rule.test === undefined) rule.test = true
+    let src = getString(rule.regex)
+    let flags = ''
+    for (const key in macros) {
+      src = src.replace(new RegExp(`{{${key}}}`, 'g'), `(?:${macros[key]})`)
+    }
+    rule.flags = rule.flags || ''
+    if (rule.flags.replace(/[biept]/g, '')) {
+      throw new Error(`'${rule.flags}' contains invalid rule flags.`)
+    }
+    if (rule.flags.includes('p')) rule.pop = true
+    if (rule.flags.includes('b')) rule.context_begins = true
+    if (rule.flags.includes('t')) rule.top_level = true
+    if (rule.flags.includes('e') || rule.eol) src += ' *(?:\\n+|$)'
+    if (rule.flags.includes('i') || rule.ignore_case) flags += 'i'
+    rule.regex = new RegExp('^(?:' + src + ')', flags)
+    if (rule.push instanceof Array) rule.push.forEach(_rule => parseRule(_rule, macros))
+  }
+  return rule as LexerRule
+}
+
+export interface LexerClass {
   config: LexerConfig
-  private rules: Record<string, NativeLexerRule[]> = {}
-  private getters: GetterFunctionMap
-  private entrance: string
-  private default: string
-  private requireBound: boolean
-  private _warnings: LexerWarning[]
-  private _isRunning: boolean = false
+  parse(source: string): any
+}
 
-  constructor(rules: LexerRules, options: LexerOptions = {}) {
-    this.getters = options.getters || {}
-    this.config = options.config || {}
-    this.entrance = options.entrance || 'main'
-    this.default = options.default || 'text'
-    this.requireBound = !!options.requireBound
-
-    const _macros = options.macros || {}
-    const macros: Record<string, string> = {}
-    for (const key in _macros) {
-      macros[key] = getString(_macros[key])
-    }
-
-    function resolve(rule: LooseLexerRule): NativeLexerRule {
-      if (!('include' in rule)) {
-        if (rule.regex === undefined) {
-          rule.regex = /(?=[\s\S])/
-          if (!rule.type) rule.type = 'default'
-        }
-        if (rule.test === undefined) rule.test = true
-        let src = getString(rule.regex)
-        let flags = ''
-        for (const key in macros) {
-          src = src.replace(new RegExp(`{{${key}}}`, 'g'), `(?:${macros[key]})`)
-        }
-        rule.flags = rule.flags || ''
-        if (rule.flags.replace(/[biept]/g, '')) {
-          throw new Error(`'${rule.flags}' contains invalid rule flags.`)
-        }
-        if (rule.flags.includes('p')) rule.pop = true
-        if (rule.flags.includes('b')) rule.context_begins = true
-        if (rule.flags.includes('t')) rule.top_level = true
-        if (rule.flags.includes('e') || rule.eol) src += ' *(?:\\n+|$)'
-        if (rule.flags.includes('i') || rule.ignore_case) flags += 'i'
-        rule.regex = new RegExp('^(?:' + src + ')', flags)
-        if (rule.push instanceof Array) rule.push.forEach(resolve)
-      }
-      return <NativeLexerRule>rule
-    }
-
-    for (const key in rules) {
-      this.rules[key] = rules[key].map(resolve)
-    }
-  }
-
-  private getContext(context: LexerContext): LexerRegexRule<RegExp>[] {
-    const result = typeof context === 'string' ? this.rules[context] : context
-    if (!result) throw new Error(`Context '${context}' was not found.`)
-    for (let i = result.length - 1; i >= 0; i -= 1) {
-      const rule: NativeLexerRule = result[i]
-      if ('include' in rule) {
-        result.splice(i, 1, ...this.getContext(rule.include))
-      }
-    }
-    return <LexerRegexRule<RegExp>[]>result
-  }
-
-  private _parse(source: string, context: LexerContext, isTopLevel: boolean = false): {
-    index: number
-    result: TokenLike[]
-    warnings: LexerWarning[]
-  } {
-    let index = 0, unmatch = ''
-    const result: TokenLike[] = []
-    const rules = this.getContext(context)
-    const warnings: LexerWarning[] = this._warnings = []
-    source = source.replace(/\r\n/g, '\n')
-    while (source) {
-      /**
-       * Matching status:
-       * 0. No match was found
-       * 1. Found match and continue
-       * 2. Found match and pop
-       */
-      let status = 0
-      for (const rule of rules) {
-        if (rule.top_level && !isTopLevel) continue
-        if (rule.context_begins && index) continue
-
-        // test
-        let test = rule.test
-        if (typeof test === 'string') {
-          if (test.charAt(0) === '!') {
-            test = !this.config[test.slice(1)]
-          } else {
-            test = this.config[test]
-          }
-        } else if (typeof test === 'function') {
-          test = test.call(this, this.config)
-        }
-        if (!test) continue
-
-        // regex
-        const capture = rule.regex.exec(source)
-        if (!capture) continue
-        source = source.slice(capture[0].length)
-        const start = index
-        index += capture[0].length
-
-        // pop
-        const pop = rule.pop
-        status = pop ? 2 : 1
-
-        // push
-        let content: TokenLike[] = [], push = rule.push
-        if (typeof push === 'function') push = push.call(this, capture)
-        if (push) {
-          const subtoken = this._parse(source, <LexerContext>push)
-          content = subtoken.result.map((tok) => {
-            if (this.requireBound && typeof tok === 'object') {
-              tok.start += index
-              tok.end += index
-            }
-            return tok
-          })
-          warnings.concat(subtoken.warnings)
-          source = source.slice(subtoken.index)
-          index += subtoken.index
-        }
-
-        // detect error
-        if (!pop && index === start) {
-          throw new Error(`Endless loop at '${
-            source.slice(0, 10)
-            } ${
-            source.length > 10 ? '...' : ''
-            }'.`)
-        }
-
-        // resolve unmatch
-        if (unmatch) {
-          result.push(unmatch)
-          unmatch = ''
-        }
-
-        // token
-        let token = rule.token
-        if (typeof token === 'function') {
-          for (const key in this.getters) { // redundant define led to some efficiency loss, consider monkey-patch RegExpExecArray or try other solutions?
-            Object.defineProperty(capture, key, {
-              get: () => this.getters[key].call(this, capture)
-            })
-          }
-          token = token.call(this, capture, content)
-        } else if (token === undefined) {
-          if (push) {
-            token = content
-          } else if (!pop) {
-            token = capture[0]
-          }
-        }
-        if (token instanceof Array) token = { content: token }
-        if (token) {
-          if (typeof token === 'object') {
-            token.type = token.type || rule.type
-            if (this.requireBound) {
-              token.start = start
-              token.end = index
-            }
-          }
-          result.push(token)
-        }
-
-        break
-      }
-
-      if (!status) {
-        unmatch += source.charAt(0)
-        source = source.slice(1)
-        index += 1
-      }
-      if (status === 2) break
-    }
-
-    if (unmatch) result.push(unmatch)
-    return { index, result, warnings }
-  }
-
-  pushWarning(message: string) {
-    this._warnings.push({ message })
-  }
-
-  parse(source: string, context?: string): TokenLike[] {
-    let result
-    if (this._isRunning) {
-      result = this._parse(source, context || this.default).result
-    } else {
-      this._isRunning = true
-      result = this._parse(source, context || this.entrance, true).result
-      this._isRunning = false
-    }
-    return result
-  }
+export enum MatchStatus {
+  /** No match was found */
+  NO_MATCH,
+  /** Found match and continue */
+  CONTINUE,
+  /** Found match and pop */
+  POP,
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/detok/package.json
+++ b/packages/detok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/detok",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A detokenizer for marklet.",
   "author": "jjyyxx <1449843302@qq.com>",
   "contributors": [
@@ -24,6 +24,6 @@
     "cheerio": "^1.0.0-rc.2"
   },
   "devDependencies": {
-    "@marklet/core": "^1.0.4"
+    "@marklet/core": "^2.0.0"
   }
 }

--- a/packages/detok/tsconfig.json
+++ b/packages/detok/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/dev-server/package.json
+++ b/packages/dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/dev-server",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A develop server for marklet.",
   "author": "jjyyxx <1449843302@qq.com>",
   "contributors": [
@@ -21,7 +21,7 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/parser": "^1.0.4",
+    "@marklet/parser": "^1.1.0",
     "@marklet/renderer": "^1.1.2",
     "vue": "^2.5.17",
     "ws": "^6.0.0"

--- a/packages/dev-server/tsconfig.json
+++ b/packages/dev-server/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/obstudio/Marklet/issues"
+  },
+  "dependencies": {
+    "@marklet/core": "^2.0.0-beta.0"
   }
 }

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@marklet/parser",
-  "version": "1.0.9",
-  "description": "A document lexer for marklet.",
+  "name": "@marklet/inline",
+  "version": "1.0.0",
+  "description": "An inline lexer for marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [
     "jjyyxx <1449843302@qq.com>"
@@ -19,9 +19,5 @@
   },
   "bugs": {
     "url": "https://github.com/obstudio/Marklet/issues"
-  },
-  "dependencies": {
-    "@marklet/core": "^1.0.4",
-    "@marklet/inline": "^1.0.0"
   }
 }

--- a/packages/inline/package.json
+++ b/packages/inline/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^2.0.0-beta.0"
+    "@marklet/core": "^2.0.0"
   }
 }

--- a/packages/inline/src/index.ts
+++ b/packages/inline/src/index.ts
@@ -1,0 +1,289 @@
+type ResultMap<T extends Record<string, (...arg: any[]) => any>> = {
+  [key in keyof T]: ReturnType<T[key]>
+}
+
+type StringLike = string | RegExp
+type Capture = RegExpExecArray & ResultMap<GetterFunctionMap>
+type GetterFunction = (this: InlineLexer, capture: RegExpExecArray) => any
+type GetterFunctionMap = Record<string, GetterFunction>
+export interface LexerConfig { [key: string]: any }
+export interface LexerOptions {
+  /** lexer capture getters */
+  getters?: GetterFunctionMap
+  /** lexer rule regex macros */
+  macros?: Record<string, StringLike>
+  /** entrance context */
+  entrance?: string
+  /** default context */
+  default?: string
+  /** assign start/end to tokens */
+  requireBound?: boolean
+  /** other configurations */
+  config?: LexerConfig
+}
+
+export interface LexerToken {
+  type?: string
+  text?: string
+  content?: TokenLike[]
+  start?: number
+  end?: number
+  [key: string]: any
+}
+
+export type TokenLike = string | LexerToken
+interface LexerIncludeRule { include: string }
+interface LexerRegexRule<S extends StringLike> {
+  /** the regular expression to execute */
+  regex?: S
+  /**
+   * a string containing all the rule flags:
+   * - `b`: match when the context begins
+   * - `e`: match end of line
+   * - `i`: ignore case
+   * - `p`: pop from the current context
+   * - `t`: match top level context
+   */
+  flags?: string
+  /** default type of the token */
+  type?: string
+  /** whether the rule is to be executed */
+  test?: string | boolean | ((config: LexerConfig) => boolean)
+  /** a result token */
+  token?: TokenLike | TokenLike[] | ((
+    this: InlineLexer, capture: Capture, content: TokenLike[], rule: this
+  ) => TokenLike | TokenLike[])
+  /** the inner context */
+  push?: string | LexerRule<S>[] | ((
+    this: InlineLexer, capture: Capture
+  ) => string | LexerRule<S>[] | false)
+  /** pop from the current context */
+  pop?: boolean
+  /** match when the context begins */
+  context_begins?: boolean
+  /** match top level context */
+  top_level?: boolean
+  /** whether to ignore case */
+  ignore_case?: boolean
+  /** match end of line */
+  eol?: boolean
+}
+
+interface LexerWarning {
+  message: string
+}
+
+type LexerContext = string | NativeLexerRule[]
+type LexerRule<S extends StringLike> = LexerRegexRule<S> | LexerIncludeRule
+type LooseLexerRule = LexerRule<StringLike>
+type NativeLexerRule = LexerRule<RegExp>
+export type LexerRules = Record<string, LooseLexerRule[]>
+
+function getString(string: StringLike): string {
+  return string instanceof RegExp ? string.source : string
+}
+
+export class InlineLexer {
+  config: LexerConfig
+  private rules: Record<string, NativeLexerRule[]> = {}
+  private getters: GetterFunctionMap
+  private entrance: string
+  private default: string
+  private requireBound: boolean
+  private _warnings: LexerWarning[]
+  private _isRunning: boolean = false
+
+  constructor(rules: LexerRules, options: LexerOptions = {}) {
+    this.getters = options.getters || {}
+    this.config = options.config || {}
+    this.entrance = options.entrance || 'main'
+    this.default = options.default || 'text'
+    this.requireBound = !!options.requireBound
+
+    const _macros = options.macros || {}
+    const macros: Record<string, string> = {}
+    for (const key in _macros) {
+      macros[key] = getString(_macros[key])
+    }
+
+    function resolve(rule: LooseLexerRule): NativeLexerRule {
+      if (!('include' in rule)) {
+        if (rule.regex === undefined) {
+          rule.regex = /(?=[\s\S])/
+          if (!rule.type) rule.type = 'default'
+        }
+        if (rule.test === undefined) rule.test = true
+        let src = getString(rule.regex)
+        let flags = ''
+        for (const key in macros) {
+          src = src.replace(new RegExp(`{{${key}}}`, 'g'), `(?:${macros[key]})`)
+        }
+        rule.flags = rule.flags || ''
+        if (rule.flags.replace(/[biept]/g, '')) {
+          throw new Error(`'${rule.flags}' contains invalid rule flags.`)
+        }
+        if (rule.flags.includes('p')) rule.pop = true
+        if (rule.flags.includes('b')) rule.context_begins = true
+        if (rule.flags.includes('t')) rule.top_level = true
+        if (rule.flags.includes('e') || rule.eol) src += ' *(?:\\n+|$)'
+        if (rule.flags.includes('i') || rule.ignore_case) flags += 'i'
+        rule.regex = new RegExp('^(?:' + src + ')', flags)
+        if (rule.push instanceof Array) rule.push.forEach(resolve)
+      }
+      return <NativeLexerRule>rule
+    }
+
+    for (const key in rules) {
+      this.rules[key] = rules[key].map(resolve)
+    }
+  }
+
+  private getContext(context: LexerContext): LexerRegexRule<RegExp>[] {
+    const result = typeof context === 'string' ? this.rules[context] : context
+    if (!result) throw new Error(`Context '${context}' was not found.`)
+    for (let i = result.length - 1; i >= 0; i -= 1) {
+      const rule: NativeLexerRule = result[i]
+      if ('include' in rule) {
+        result.splice(i, 1, ...this.getContext(rule.include))
+      }
+    }
+    return <LexerRegexRule<RegExp>[]>result
+  }
+
+  private _parse(source: string, context: LexerContext, isTopLevel: boolean = false): {
+    index: number
+    result: TokenLike[]
+    warnings: LexerWarning[]
+  } {
+    let index = 0, unmatch = ''
+    const result: TokenLike[] = []
+    const rules = this.getContext(context)
+    const warnings: LexerWarning[] = this._warnings = []
+    source = source.replace(/\r\n/g, '\n')
+    while (source) {
+      /**
+       * Matching status:
+       * 0. No match was found
+       * 1. Found match and continue
+       * 2. Found match and pop
+       */
+      let status = 0
+      for (const rule of rules) {
+        if (rule.top_level && !isTopLevel) continue
+        if (rule.context_begins && index) continue
+
+        // test
+        let test = rule.test
+        if (typeof test === 'string') {
+          if (test.charAt(0) === '!') {
+            test = !this.config[test.slice(1)]
+          } else {
+            test = this.config[test]
+          }
+        } else if (typeof test === 'function') {
+          test = test.call(this, this.config)
+        }
+        if (!test) continue
+
+        // regex
+        const capture = rule.regex.exec(source)
+        if (!capture) continue
+        source = source.slice(capture[0].length)
+        const start = index
+        index += capture[0].length
+
+        // pop
+        const pop = rule.pop
+        status = pop ? 2 : 1
+
+        // push
+        let content: TokenLike[] = [], push = rule.push
+        if (typeof push === 'function') push = push.call(this, capture)
+        if (push) {
+          const subtoken = this._parse(source, <LexerContext>push)
+          content = subtoken.result.map((tok) => {
+            if (this.requireBound && typeof tok === 'object') {
+              tok.start += index
+              tok.end += index
+            }
+            return tok
+          })
+          warnings.concat(subtoken.warnings)
+          source = source.slice(subtoken.index)
+          index += subtoken.index
+        }
+
+        // detect error
+        if (!pop && index === start) {
+          throw new Error(`Endless loop at '${
+            source.slice(0, 10)
+            } ${
+            source.length > 10 ? '...' : ''
+            }'.`)
+        }
+
+        // resolve unmatch
+        if (unmatch) {
+          result.push(unmatch)
+          unmatch = ''
+        }
+
+        // token
+        let token = rule.token
+        if (typeof token === 'function') {
+          for (const key in this.getters) { // redundant define led to some efficiency loss, consider monkey-patch RegExpExecArray or try other solutions?
+            Object.defineProperty(capture, key, {
+              get: () => this.getters[key].call(this, capture)
+            })
+          }
+          token = token.call(this, capture, content)
+        } else if (token === undefined) {
+          if (push) {
+            token = content
+          } else if (!pop) {
+            token = capture[0]
+          }
+        }
+        if (token instanceof Array) token = { content: token }
+        if (token) {
+          if (typeof token === 'object') {
+            token.type = token.type || rule.type
+            if (this.requireBound) {
+              token.start = start
+              token.end = index
+            }
+          }
+          result.push(token)
+        }
+
+        break
+      }
+
+      if (!status) {
+        unmatch += source.charAt(0)
+        source = source.slice(1)
+        index += 1
+      }
+      if (status === 2) break
+    }
+
+    if (unmatch) result.push(unmatch)
+    return { index, result, warnings }
+  }
+
+  pushWarning(message: string) {
+    this._warnings.push({ message })
+  }
+
+  parse(source: string, context?: string): TokenLike[] {
+    let result
+    if (this._isRunning) {
+      result = this._parse(source, context || this.default).result
+    } else {
+      this._isRunning = true
+      result = this._parse(source, context || this.entrance, true).result
+      this._isRunning = false
+    }
+    return result
+  }
+}

--- a/packages/inline/src/index.ts
+++ b/packages/inline/src/index.ts
@@ -1,13 +1,12 @@
 import {
   StringLike,
   LexerConfig,
-  LexerClass,
   LexerRegexRule,
+  InlineLexerInstance,
+  InlineLexerResult,
   MatchStatus,
   parseRule,
 } from '@marklet/core'
-
-export { LexerConfig }
 
 class InlineCapture extends Array<string> implements RegExpExecArray {
   index: number
@@ -30,18 +29,14 @@ class InlineCapture extends Array<string> implements RegExpExecArray {
 type InlineLexerRule<S extends StringLike = RegExp> = LexerRegexRule<S, InlineLexer, InlineCapture>
 
 export type InlineLexerRules = InlineLexerRule<StringLike>[]
-export interface InlineLexerResult {
-  index: number
-  output: string
-}
 
-export class InlineLexer implements LexerClass {
+export class InlineLexer implements InlineLexerInstance {
   config: LexerConfig
   private rules: InlineLexerRule[]
 
   constructor(rules: InlineLexerRules, config: LexerConfig = {}) {
     this.rules = rules.map(rule => parseRule(rule) as InlineLexerRule)
-    this.config = config
+    this.config = config || {}
   }
 
   private _parse(source: string): InlineLexerResult {
@@ -67,7 +62,7 @@ export class InlineLexer implements LexerClass {
         // regex
         const match = rule.regex.exec(source)
         if (!match) continue
-        if (!match[0].length) {
+        if (!match[0].length && !rule.pop) {
           throw new Error(`Endless loop at '${
             source.slice(0, 10)
           } ${

--- a/packages/inline/tsconfig.json
+++ b/packages/inline/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/inline/tsconfig.json
+++ b/packages/inline/tsconfig.json
@@ -6,5 +6,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"
-  }
+  },
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/packages/inline/tsconfig.json
+++ b/packages/inline/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/lexer/package.json
+++ b/packages/lexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/lexer",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A document lexer for marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [
@@ -21,6 +21,6 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^2.0.0-beta"
+    "@marklet/core": "^2.0.0"
   }
 }

--- a/packages/lexer/package.json
+++ b/packages/lexer/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^1.0.9"
+    "@marklet/core": "^2.0.0-beta"
   }
 }

--- a/packages/lexer/package.json
+++ b/packages/lexer/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@marklet/inline",
-  "version": "1.0.0",
-  "description": "A fast inline lexer for marklet.",
+  "name": "@marklet/lexer",
+  "version": "1.0.9",
+  "description": "A document lexer for marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [
     "jjyyxx <1449843302@qq.com>"
@@ -19,5 +19,8 @@
   },
   "bugs": {
     "url": "https://github.com/obstudio/Marklet/issues"
+  },
+  "dependencies": {
+    "@marklet/core": "^1.0.9"
   }
 }

--- a/packages/lexer/src/index.ts
+++ b/packages/lexer/src/index.ts
@@ -1,21 +1,21 @@
-type StringLike = string | RegExp
-function getString(string: StringLike): string {
-  return string instanceof RegExp ? string.source : string
-}
+import {
+  StringLike,
+  LexerMacros,
+  LexerConfig,
+  LexerClass,
+  LexerRule,
+  TokenLike,
+  LexerRegexRule,
+  MatchStatus,
+  parseRule,
+  getString,
+} from '@marklet/core'
 
-type ResultMap<T extends Record<string, (...arg: any[]) => any>> = {
-  [key in keyof T]: ReturnType<T[key]>
-}
+export { LexerConfig }
 
-type Capture = RegExpExecArray & ResultMap<GetterFunctionMap>
-type GetterFunction = (this: Lexer, capture: RegExpExecArray) => any
-type GetterFunctionMap = Record<string, GetterFunction>
-export interface LexerConfig { [key: string]: any }
 export interface LexerOptions {
-  /** lexer capture getters */
-  getters?: GetterFunctionMap
   /** lexer rule regex macros */
-  macros?: Record<string, StringLike>
+  macros?: LexerMacros
   /** entrance context */
   entrance?: string
   /** default context */
@@ -26,67 +26,22 @@ export interface LexerOptions {
   config?: LexerConfig
 }
 
-export interface LexerToken {
-  type?: string
-  text?: string
-  content?: TokenLike[]
-  start?: number
-  end?: number
-  [key: string]: any
-}
-
-export type TokenLike = string | LexerToken
-interface LexerIncludeRule { include: string }
-interface LexerRegexRule<S extends StringLike> {
-  /** the regular expression to execute */
-  regex?: S
-  /**
-   * a string containing all the rule flags:
-   * - `b`: match when the context begins
-   * - `e`: match end of line
-   * - `i`: ignore case
-   * - `p`: pop from the current context
-   * - `t`: match top level context
-   */
-  flags?: string
-  /** default type of the token */
-  type?: string
-  /** whether the rule is to be executed */
-  test?: string | boolean | ((this: Lexer, config: LexerConfig) => boolean)
-  /** a result token */
-  token?: TokenLike | TokenLike[] | ((
-    this: Lexer, capture: Capture, content: TokenLike[]
-  ) => TokenLike | TokenLike[])
-  /** the inner context */
-  push?: string | LexerRule<S>[] | ((
-    this: Lexer, capture: Capture
-  ) => string | LexerRule<S>[] | false)
-  /** pop from the current context */
-  pop?: boolean
-  /** match when the context begins */
-  context_begins?: boolean
-  /** match top level context */
-  top_level?: boolean
-  /** whether to ignore case */
-  ignore_case?: boolean
-  /** match end of line */
-  eol?: boolean
-}
-
 interface LexerWarning {
   message: string
 }
 
-type LexerContext = string | NativeLexerRule[]
-type LexerRule<S extends StringLike> = LexerRegexRule<S> | LexerIncludeRule
-type LooseLexerRule = LexerRule<StringLike>
-type NativeLexerRule = LexerRule<RegExp>
-export type LexerRules = Record<string, LooseLexerRule[]>
+type LexerContext = string | LexerRule[]
+export type LexerRules = Record<string, LexerRule<StringLike>[]>
 
-export class Lexer {
+interface LexerResult {
+  index: number
+  result: TokenLike[]
+  warnings: LexerWarning[]
+}
+
+export class Lexer implements LexerClass {
   config: LexerConfig
-  private rules: Record<string, NativeLexerRule[]> = {}
-  private getters: GetterFunctionMap
+  private rules: Record<string, LexerRule[]> = {}
   private entrance: string
   private default: string
   private requireBound: boolean
@@ -94,7 +49,6 @@ export class Lexer {
   private _isRunning: boolean = false
 
   constructor(rules: LexerRules, options: LexerOptions = {}) {
-    this.getters = options.getters || {}
     this.config = options.config || {}
     this.entrance = options.entrance || 'main'
     this.default = options.default || 'text'
@@ -105,36 +59,8 @@ export class Lexer {
     for (const key in _macros) {
       macros[key] = getString(_macros[key])
     }
-
-    function resolve(rule: LooseLexerRule): NativeLexerRule {
-      if (!('include' in rule)) {
-        if (rule.regex === undefined) {
-          rule.regex = /(?=[\s\S])/
-          if (!rule.type) rule.type = 'default'
-        }
-        if (rule.test === undefined) rule.test = true
-        let src = getString(rule.regex)
-        let flags = ''
-        for (const key in macros) {
-          src = src.replace(new RegExp(`{{${key}}}`, 'g'), `(?:${macros[key]})`)
-        }
-        rule.flags = rule.flags || ''
-        if (rule.flags.replace(/[biept]/g, '')) {
-          throw new Error(`'${rule.flags}' contains invalid rule flags.`)
-        }
-        if (rule.flags.includes('p')) rule.pop = true
-        if (rule.flags.includes('b')) rule.context_begins = true
-        if (rule.flags.includes('t')) rule.top_level = true
-        if (rule.flags.includes('e') || rule.eol) src += ' *(?:\\n+|$)'
-        if (rule.flags.includes('i') || rule.ignore_case) flags += 'i'
-        rule.regex = new RegExp('^(?:' + src + ')', flags)
-        if (rule.push instanceof Array) rule.push.forEach(resolve)
-      }
-      return rule as NativeLexerRule
-    }
-
     for (const key in rules) {
-      this.rules[key] = rules[key].map(resolve)
+      this.rules[key] = rules[key].map(rule => parseRule(rule, macros))
     }
   }
 
@@ -142,31 +68,21 @@ export class Lexer {
     const result = typeof context === 'string' ? this.rules[context] : context
     if (!result) throw new Error(`Context '${context}' was not found.`)
     for (let i = result.length - 1; i >= 0; i -= 1) {
-      const rule: NativeLexerRule = result[i]
+      const rule: LexerRule = result[i]
       if ('include' in rule) {
         result.splice(i, 1, ...this.getContext(rule.include))
       }
     }
-    return <LexerRegexRule<RegExp>[]>result
+    return result as LexerRegexRule<RegExp>[]
   }
 
-  private _parse(source: string, context: LexerContext, isTopLevel: boolean = false): {
-    index: number
-    result: TokenLike[]
-    warnings: LexerWarning[]
-  } {
+  private _parse(source: string, context: LexerContext, isTopLevel: boolean = false): LexerResult {
     let index = 0, unmatch = ''
     const result: TokenLike[] = []
     const rules = this.getContext(context)
     const warnings: LexerWarning[] = this._warnings = []
     while (source) {
-      /**
-       * Matching status:
-       * 0. No match was found
-       * 1. Found match and continue
-       * 2. Found match and pop
-       */
-      let status = 0
+      let status: MatchStatus = MatchStatus.NO_MATCH
       for (const rule of rules) {
         if (rule.top_level && !isTopLevel) continue
         if (rule.context_begins && index) continue
@@ -193,11 +109,10 @@ export class Lexer {
 
         // pop
         const pop = rule.pop
-        status = pop ? 2 : 1
+        status = pop ? MatchStatus.POP : MatchStatus.CONTINUE
 
         // push
         let content: TokenLike[] = [], push = rule.push
-        if (typeof push === 'function') push = push.call(this, capture)
         if (push) {
           const subtoken = this._parse(source, <LexerContext>push)
           content = subtoken.result.map((tok) => {
@@ -230,11 +145,6 @@ export class Lexer {
         // token
         let token = rule.token
         if (typeof token === 'function') {
-          for (const key in this.getters) { // redundant define led to some efficiency loss, consider monkey-patch RegExpExecArray or try other solutions?
-            Object.defineProperty(capture, key, {
-              get: () => this.getters[key].call(this, capture)
-            })
-          }
           token = token.call(this, capture, content)
         } else if (token === undefined) {
           if (push) {
@@ -258,8 +168,8 @@ export class Lexer {
         break
       }
 
-      if (status === 2) break
-      if (status === 0) {
+      if (status === MatchStatus.POP) break
+      if (status === MatchStatus.NO_MATCH) {
         unmatch += source.charAt(0)
         source = source.slice(1)
         index += 1

--- a/packages/lexer/src/index.ts
+++ b/packages/lexer/src/index.ts
@@ -1,0 +1,289 @@
+type StringLike = string | RegExp
+function getString(string: StringLike): string {
+  return string instanceof RegExp ? string.source : string
+}
+
+type ResultMap<T extends Record<string, (...arg: any[]) => any>> = {
+  [key in keyof T]: ReturnType<T[key]>
+}
+
+type Capture = RegExpExecArray & ResultMap<GetterFunctionMap>
+type GetterFunction = (this: Lexer, capture: RegExpExecArray) => any
+type GetterFunctionMap = Record<string, GetterFunction>
+export interface LexerConfig { [key: string]: any }
+export interface LexerOptions {
+  /** lexer capture getters */
+  getters?: GetterFunctionMap
+  /** lexer rule regex macros */
+  macros?: Record<string, StringLike>
+  /** entrance context */
+  entrance?: string
+  /** default context */
+  default?: string
+  /** assign start/end to tokens */
+  requireBound?: boolean
+  /** other configurations */
+  config?: LexerConfig
+}
+
+export interface LexerToken {
+  type?: string
+  text?: string
+  content?: TokenLike[]
+  start?: number
+  end?: number
+  [key: string]: any
+}
+
+export type TokenLike = string | LexerToken
+interface LexerIncludeRule { include: string }
+interface LexerRegexRule<S extends StringLike> {
+  /** the regular expression to execute */
+  regex?: S
+  /**
+   * a string containing all the rule flags:
+   * - `b`: match when the context begins
+   * - `e`: match end of line
+   * - `i`: ignore case
+   * - `p`: pop from the current context
+   * - `t`: match top level context
+   */
+  flags?: string
+  /** default type of the token */
+  type?: string
+  /** whether the rule is to be executed */
+  test?: string | boolean | ((this: Lexer, config: LexerConfig) => boolean)
+  /** a result token */
+  token?: TokenLike | TokenLike[] | ((
+    this: Lexer, capture: Capture, content: TokenLike[]
+  ) => TokenLike | TokenLike[])
+  /** the inner context */
+  push?: string | LexerRule<S>[] | ((
+    this: Lexer, capture: Capture
+  ) => string | LexerRule<S>[] | false)
+  /** pop from the current context */
+  pop?: boolean
+  /** match when the context begins */
+  context_begins?: boolean
+  /** match top level context */
+  top_level?: boolean
+  /** whether to ignore case */
+  ignore_case?: boolean
+  /** match end of line */
+  eol?: boolean
+}
+
+interface LexerWarning {
+  message: string
+}
+
+type LexerContext = string | NativeLexerRule[]
+type LexerRule<S extends StringLike> = LexerRegexRule<S> | LexerIncludeRule
+type LooseLexerRule = LexerRule<StringLike>
+type NativeLexerRule = LexerRule<RegExp>
+export type LexerRules = Record<string, LooseLexerRule[]>
+
+export class Lexer {
+  config: LexerConfig
+  private rules: Record<string, NativeLexerRule[]> = {}
+  private getters: GetterFunctionMap
+  private entrance: string
+  private default: string
+  private requireBound: boolean
+  private _warnings: LexerWarning[]
+  private _isRunning: boolean = false
+
+  constructor(rules: LexerRules, options: LexerOptions = {}) {
+    this.getters = options.getters || {}
+    this.config = options.config || {}
+    this.entrance = options.entrance || 'main'
+    this.default = options.default || 'text'
+    this.requireBound = !!options.requireBound
+
+    const _macros = options.macros || {}
+    const macros: Record<string, string> = {}
+    for (const key in _macros) {
+      macros[key] = getString(_macros[key])
+    }
+
+    function resolve(rule: LooseLexerRule): NativeLexerRule {
+      if (!('include' in rule)) {
+        if (rule.regex === undefined) {
+          rule.regex = /(?=[\s\S])/
+          if (!rule.type) rule.type = 'default'
+        }
+        if (rule.test === undefined) rule.test = true
+        let src = getString(rule.regex)
+        let flags = ''
+        for (const key in macros) {
+          src = src.replace(new RegExp(`{{${key}}}`, 'g'), `(?:${macros[key]})`)
+        }
+        rule.flags = rule.flags || ''
+        if (rule.flags.replace(/[biept]/g, '')) {
+          throw new Error(`'${rule.flags}' contains invalid rule flags.`)
+        }
+        if (rule.flags.includes('p')) rule.pop = true
+        if (rule.flags.includes('b')) rule.context_begins = true
+        if (rule.flags.includes('t')) rule.top_level = true
+        if (rule.flags.includes('e') || rule.eol) src += ' *(?:\\n+|$)'
+        if (rule.flags.includes('i') || rule.ignore_case) flags += 'i'
+        rule.regex = new RegExp('^(?:' + src + ')', flags)
+        if (rule.push instanceof Array) rule.push.forEach(resolve)
+      }
+      return rule as NativeLexerRule
+    }
+
+    for (const key in rules) {
+      this.rules[key] = rules[key].map(resolve)
+    }
+  }
+
+  private getContext(context: LexerContext): LexerRegexRule<RegExp>[] {
+    const result = typeof context === 'string' ? this.rules[context] : context
+    if (!result) throw new Error(`Context '${context}' was not found.`)
+    for (let i = result.length - 1; i >= 0; i -= 1) {
+      const rule: NativeLexerRule = result[i]
+      if ('include' in rule) {
+        result.splice(i, 1, ...this.getContext(rule.include))
+      }
+    }
+    return <LexerRegexRule<RegExp>[]>result
+  }
+
+  private _parse(source: string, context: LexerContext, isTopLevel: boolean = false): {
+    index: number
+    result: TokenLike[]
+    warnings: LexerWarning[]
+  } {
+    let index = 0, unmatch = ''
+    const result: TokenLike[] = []
+    const rules = this.getContext(context)
+    const warnings: LexerWarning[] = this._warnings = []
+    while (source) {
+      /**
+       * Matching status:
+       * 0. No match was found
+       * 1. Found match and continue
+       * 2. Found match and pop
+       */
+      let status = 0
+      for (const rule of rules) {
+        if (rule.top_level && !isTopLevel) continue
+        if (rule.context_begins && index) continue
+
+        // test
+        let test = rule.test
+        if (typeof test === 'string') {
+          if (test.charAt(0) === '!') {
+            test = !this.config[test.slice(1)]
+          } else {
+            test = !!this.config[test]
+          }
+        } else if (typeof test === 'function') {
+          test = test.call(this, this.config)
+        }
+        if (!test) continue
+
+        // regex
+        const capture = rule.regex.exec(source)
+        if (!capture) continue
+        source = source.slice(capture[0].length)
+        const start = index
+        index += capture[0].length
+
+        // pop
+        const pop = rule.pop
+        status = pop ? 2 : 1
+
+        // push
+        let content: TokenLike[] = [], push = rule.push
+        if (typeof push === 'function') push = push.call(this, capture)
+        if (push) {
+          const subtoken = this._parse(source, <LexerContext>push)
+          content = subtoken.result.map((tok) => {
+            if (this.requireBound && typeof tok === 'object') {
+              tok.start += index
+              tok.end += index
+            }
+            return tok
+          })
+          warnings.concat(subtoken.warnings)
+          source = source.slice(subtoken.index)
+          index += subtoken.index
+        }
+
+        // detect error
+        if (!pop && index === start) {
+          throw new Error(`Endless loop at '${
+            source.slice(0, 10)
+            } ${
+            source.length > 10 ? '...' : ''
+            }'.`)
+        }
+
+        // resolve unmatch
+        if (unmatch) {
+          result.push(unmatch)
+          unmatch = ''
+        }
+
+        // token
+        let token = rule.token
+        if (typeof token === 'function') {
+          for (const key in this.getters) { // redundant define led to some efficiency loss, consider monkey-patch RegExpExecArray or try other solutions?
+            Object.defineProperty(capture, key, {
+              get: () => this.getters[key].call(this, capture)
+            })
+          }
+          token = token.call(this, capture, content)
+        } else if (token === undefined) {
+          if (push) {
+            token = content
+          } else if (!pop) {
+            token = capture[0]
+          }
+        }
+        if (token instanceof Array) token = { content: token }
+        if (token) {
+          if (typeof token === 'object') {
+            token.type = token.type || rule.type
+            if (this.requireBound) {
+              token.start = start
+              token.end = index
+            }
+          }
+          result.push(token)
+        }
+
+        break
+      }
+
+      if (status === 2) break
+      if (status === 0) {
+        unmatch += source.charAt(0)
+        source = source.slice(1)
+        index += 1
+      }
+    }
+
+    if (unmatch) result.push(unmatch)
+    return { index, result, warnings }
+  }
+
+  pushWarning(message: string) {
+    this._warnings.push({ message })
+  }
+
+  parse(source: string, context?: string): TokenLike[] {
+    let result
+    source = source.replace(/\r\n/g, '\n')
+    if (this._isRunning) {
+      result = this._parse(source, context || this.default).result
+    } else {
+      this._isRunning = true
+      result = this._parse(source, context || this.entrance, true).result
+      this._isRunning = false
+    }
+    return result
+  }
+}

--- a/packages/lexer/tsconfig.json
+++ b/packages/lexer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/lexer/tsconfig.json
+++ b/packages/lexer/tsconfig.json
@@ -6,5 +6,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"
-  }
+  },
+  "references": [
+    { "path": "../core" }
+  ]
 }

--- a/packages/lexer/tsconfig.json
+++ b/packages/lexer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src"
+  ],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}

--- a/packages/marklet/package.json
+++ b/packages/marklet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markletjs",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "A markup language designed for API manual pages.",
   "author": "jjyyxx <1449843302@qq.com>",
   "contributors": [
@@ -28,8 +28,8 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/cli": "^1.1.4",
-    "@marklet/parser": "^1.0.4",
+    "@marklet/cli": "^1.1.5",
+    "@marklet/parser": "^1.1.0",
     "@marklet/renderer": "^1.1.2"
   }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -21,7 +21,8 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^1.0.4",
+    "@marklet/core": "^2.0.0-beta.0",
+    "@marklet/lexer": "^1.0.9",
     "@marklet/inline": "^1.0.0"
   }
 }

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/parser",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "A document lexer for marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "contributors": [
@@ -21,8 +21,8 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^2.0.0-beta.0",
-    "@marklet/lexer": "^1.0.9",
+    "@marklet/core": "^2.0.0",
+    "@marklet/lexer": "^1.0.10",
     "@marklet/inline": "^1.0.0"
   }
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,4 +1,5 @@
 import { Lexer, LexerConfig, TokenLike } from '@marklet/core'
+import { InlineLexer } from '@marklet/inline'
 
 function escape(html: string): string {
   return html

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,5 +1,6 @@
-import { Lexer, LexerConfig, TokenLike } from '@marklet/core'
+import { LexerConfig, TokenLike, InlineLexerInstance } from '@marklet/core'
 import { InlineLexer } from '@marklet/inline'
+import { Lexer } from '@marklet/lexer'
 
 function escape(html: string): string {
   return html
@@ -23,183 +24,59 @@ interface MarkletLexerConfig extends LexerConfig {
   default_language?: string
 }
 
-class MarkletLexer extends Lexer {
+class MarkletInlineLexer extends InlineLexer {
   constructor(config: MarkletLexerConfig = {}) {
-    super({
-      main: [{
-        type: 'newline',
-        regex: /\n+/,
-        token: null
-      }, {
-        type: 'heading',
-        regex: /(#{1,4}) +([^\n]+?)( +#)?/,
-        eol: true,
-        token(cap) {
-          let text, center
-          if (this.config.header_align && cap[3]) {
-            text = this.parse(cap[2], 'text').join('')
-            center = true
-          } else {
-            text = this.parse(cap[2] + (cap[3] || ''), 'text').join('')
-            center = false
-          }
-          return { level: cap[1].length, text, center }
-        }
-      }, {
-        type: 'section',
-        test: 'allow_section',
-        regex: /(\^{1,4}) +([^\n]+?)/,
-        eol: true,
-        push: 'main',
-        token(cap) {
-          const text = this.parse(cap[2], 'text').join('')
-          return { level: cap[1].length, text }
-        }
-      }, {
-        type: 'quote',
-        regex: />([\w-]*) +/,
-        push: 'block',
-        token: (cap, content) => ({ style: cap[1], content })
-      }, {
-        type: 'separator',
-        regex: / *([-=])(\1|\.\1| \1)\2+/,
-        eol: true,
-        token: (cap) => ({
-          thick: cap[1] === '=',
-          style: cap[2].length === 1 ? 'normal'
-            : cap[2][0] === ' ' ? 'dashed' : 'dotted'
-        })
-      }, {
-        type: 'codeblock',
-        regex: / *(`{3,}) *([\w-]+)? *\n([\s\S]*?)\n? *\1/,
-        eol: true,
-        token(cap) {
-          return {
-            lang: cap[2] || this.config.default_language,
-            text: cap[3] || '',
-          }
-        }
-      }, {
-        type: 'usages',
-        regex: /(?= *\? +\S)/,
-        push: [{
-          type: 'usage',
-          regex: / *\? +([^\n]+?)/,
-          eol: true,
-          push: [{
-            regex: /(?= *\? )/,
-            pop: true
-          }, {
-            include: 'text'
-          }],
-          token(cap, cont) {
-            return {
-              text: this.parse(cap[1], 'text').join(''),
-              content: cont
-            }
-          }
-        }, {
-          pop: true
-        }]
-      }, {
-        type: 'list',
-        regex: / *(?={{bullet}} +[^\n]+)/,
-        push: [{
-          type: 'item',
-          regex: /( *)({{bullet}}) +(?=[^\n]+)/,
-          push: [{
-            regex: /\n? *(?={{bullet}} +[^\n]+)/,
-            pop: true
-          }, {
-            include: 'text'
-          }],
-          token(cap, cont) {
-            return {
-              text: cont.join(''),
-              ordered: cap[2].length > 1,
-              indent: cap[1].length,
-            }
-          }
-        }, {
-          pop: true
-        }],
-        token: (_, cont) => collect(cont)
-      }, {
-        type: 'inlinelist',
-        regex: /(?=\+)/,
-        push: [{
-          type: 'item',
-          regex: /\+/,
-          push: [{
-            regex: /\+?$|\+\n(?=\+)|\+?(?=\n)|(?=\+)/,
-            pop: true
-          }, {
-            include: 'text'
-          }],
-          token(_, cont) {
-            return cont.join('')
-          }
-        }, {
-          regex: /\n|$/,
-          pop: true
-        }],
-        token: (_, cont) => ({ content: cont })
-      }, {
-        type: 'table',
-        regex: /$^/, // FIXME: placeholder for syntax discussion
-        push: [],
-        token: (_, cont) => ({ content: cont })
-      }, {
-        type: 'paragraph',
-        push: 'text',
-        token: (_, cont) => ({ text: cont.join('') })
-      }],
-      block: [{
-        regex: /\n[ \t]*\n/,
+    super([
+      {
+        regex: /(?=\n[ \t]*(\n|$))/,
         pop: true
-      }, {
-        include: 'main'
-      }],
-      text: [{
+      },
+      {
         type: 'escape',
         regex: /\\([\s\S])/,
         token: (cap) => cap[1]
-      }, {
-        regex: /(?=\n[ \t]*(\n|$))/,
-        pop: true
-      }, {
+      },
+      {
         type: 'newline',
         regex: /\n/,
         token: '<br/>'
-      }, {
+      },
+      {
         type: 'code',
         regex: /(`+)\s*([\s\S]*?[^`]?)\s*\1(?!`)/,
         token: (cap) => `<code>${escape(cap[2])}</code>`
-      }, {
+      },
+      {
         type: 'strikeout',
         regex: /-(?=\S)([\s\S]*?\S)-(?!-)/,
-        token: (cap) => `<del>${cap.next}</del>`
-      }, {
+        token: (cap) => `<del>${cap.inner}</del>`
+      },
+      {
         type: 'underline',
         regex: /_(?=\S)([\s\S]*?\S)_(?!_)/,
-        token: (cap) => `<span style="text-decoration: underline">${cap.next}</span>`
-      }, {
+        token: (cap) => `<span style="text-decoration: underline">${cap.inner}</span>`
+      },
+      {
         type: 'bold',
         regex: /\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)/,
-        token: (cap) => `<strong>${cap.next}</strong>`
-      }, {
+        token: (cap) => `<strong>${cap.inner}</strong>`
+      },
+      {
         type: 'italic',
         regex: /\*(?=\S)([\s\S]*?\S)\*(?!\*)/,
-        token: (cap) => `<em>${cap.next}</em>`
-      }, {
+        token: (cap) => `<em>${cap.inner}</em>`
+      },
+      {
         type: 'comment',
         regex: /\(\((?=\S)([\s\S]*?\S)\)\)(?!\))/,
-        token: (cap) => `<span class="comment">${cap.next}</span>`
-      }, {
+        token: (cap) => `<span class="comment">${cap.inner}</span>`
+      },
+      {
         type: 'package',
         regex: /{{(?=\S)([\s\S]*?\S)}}(?!})/,
-        token: (cap) => `<code class="package">${cap.next}</code>`
-      }, {
+        token: (cap) => `<code class="package">${cap.inner}</code>`
+      },
+      {
         type: 'link',
         regex: /\[(?:([^\]|]+)\|)?([^\]]+)\]/,
         token(cap) {
@@ -219,16 +96,180 @@ class MarkletLexer extends Lexer {
             `<img src="${cap[2].slice(1)}" alt="${text}" title="${text}">` : // TODO: special treatment like <a> necessary?
             `<a href="#" data-raw-url="${cap[2]}" onclick="event.preventDefault()"'>${text}</a>`
         }
-      }]
+      }
+    ], config)
+  }
+}
+
+class MarkletLexer extends Lexer {
+  constructor(config: MarkletLexerConfig = {}) {
+    super({
+      text: new MarkletInlineLexer(config),
+      main: [
+        {
+          type: 'newline',
+          regex: /\n+/,
+          token: null
+        },
+        {
+          type: 'heading',
+          regex: /(#{1,4}) +([^\n]+?)( +#)?/,
+          eol: true,
+          token(cap) {
+            let text, center
+            if (this.config.header_align && cap[3]) {
+              text = this.inline(cap[2])
+              center = true
+            } else {
+              text = this.inline(cap[2] + (cap[3] || ''))
+              center = false
+            }
+            return { level: cap[1].length, text, center }
+          }
+        },
+        {
+          type: 'section',
+          test: 'allow_section',
+          regex: /(\^{1,4}) +([^\n]+?)/,
+          eol: true,
+          push: 'main',
+          token(cap) {
+            return {
+              level: cap[1].length,
+              text: this.inline(cap[2]),
+            }
+          }
+        },
+        {
+          type: 'quote',
+          regex: />([\w-]*) +/,
+          push: 'block',
+          token: (cap, content) => ({ style: cap[1], content })
+        },
+        {
+          type: 'separator',
+          regex: / *([-=])(\1|\.\1| \1)\2+/,
+          eol: true,
+          token: (cap) => ({
+            thick: cap[1] === '=',
+            style: cap[2].length === 1 ? 'normal'
+              : cap[2][0] === ' ' ? 'dashed' : 'dotted'
+          })
+        },
+        {
+          type: 'codeblock',
+          regex: / *(`{3,}) *([\w-]+)? *\n([\s\S]*?)\n? *\1/,
+          eol: true,
+          token(cap) {
+            return {
+              lang: cap[2] || this.config.default_language,
+              text: cap[3] || '',
+            }
+          }
+        },
+        {
+          type: 'usages',
+          regex: /(?= *\? +\S)/,
+          strict: true,
+          push: [
+            {
+              type: 'usage',
+              regex: / *\? +([^\n]+?)/,
+              eol: true,
+              push: [
+                {
+                  regex: /(?= *\? )/,
+                  pop: true
+                },
+                {
+                  include: 'text'
+                }
+              ],
+              token(cap, cont) {
+                return {
+                  text: this.inline(cap[1]),
+                  content: cont,
+                }
+              }
+            }
+          ]
+        },
+        {
+          type: 'list',
+          regex: / *(?={{bullet}} +[^\n]+)/,
+          strict: true,
+          push: [
+            {
+              type: 'item',
+              regex: /( *)({{bullet}}) +(?=[^\n]+)/,
+              push: [{
+                regex: /\n? *(?={{bullet}} +[^\n]+)/,
+                pop: true
+              }, {
+                include: 'text'
+              }],
+              token(cap, cont) {
+                return {
+                  text: cont.join(''),
+                  ordered: cap[2].length > 1,
+                  indent: cap[1].length,
+                }
+              }
+            }
+          ],
+          token: (_, cont) => collect(cont)
+        },
+        {
+          type: 'inlinelist',
+          regex: /(?=\+)/,
+          push: [
+            {
+              type: 'item',
+              regex: /\+/,
+              push: [
+                {
+                  regex: /\+?$|\+\n(?=\+)|\+?(?=\n)|(?=\+)/,
+                  pop: true
+                },
+                {
+                  include: 'text'
+                }
+              ],
+              token(_, cont) {
+                return cont.join('')
+              }
+            },
+            {
+              regex: /\n|$/,
+              pop: true
+            }
+          ],
+          token: (_, cont) => ({ content: cont })
+        },
+        {
+          type: 'table',
+          regex: /$^/, // FIXME: placeholder for syntax discussion
+          push: [],
+          token: (_, cont) => ({ content: cont })
+        },
+        {
+          type: 'paragraph',
+          push: 'text',
+          token: (_, cont) => ({ text: cont.join('') })
+        }
+      ],
+      block: [
+        {
+          regex: /\n[ \t]*\n/,
+          pop: true
+        },
+        {
+          include: 'main'
+        }
+      ],
     }, {
       macros: {
         bullet: /-|\d+\./,
-      },
-      getters: {
-        next(capture) {
-          const result = this.parse(capture.reverse().find(item => !!item) || '')
-          return result/* .map(token => token.text || token) */.join('')
-        },
       },
       config: {
         header_align: true,
@@ -257,5 +298,6 @@ export function parse(options: ParseOptions): TokenLike[] {
 
 export {
   MarkletLexer as Lexer,
+  MarkletInlineLexer as InlineLexer,
   MarkletLexerConfig as LexerConfig,
 }

--- a/packages/parser/src/index.ts
+++ b/packages/parser/src/index.ts
@@ -1,4 +1,4 @@
-import { LexerConfig, TokenLike, InlineLexerInstance } from '@marklet/core'
+import { LexerConfig, TokenLike } from '@marklet/core'
 import { InlineLexer } from '@marklet/inline'
 import { Lexer } from '@marklet/lexer'
 

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -8,6 +8,8 @@
     "rootDir": "src"
   },
   "references": [
-    { "path": "../core" }
+    { "path": "../core" },
+    { "path": "../inline" },
+    { "path": "../lexer" }
   ]
 }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^1.0.9"
+    "@marklet/core": "^2.0.0-beta.0"
   },
   "peerDependencies": {
     "vue": "^2.5.17"

--- a/packages/syntax/package.json
+++ b/packages/syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/syntax",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A common language lexer for marklet.",
   "author": "shigma <1700011071@pku.edu.cn>",
   "homepage": "https://github.com/obstudio/Marklet",
@@ -18,7 +18,7 @@
     "url": "https://github.com/obstudio/Marklet/issues"
   },
   "dependencies": {
-    "@marklet/core": "^1.0.4",
+    "@marklet/lexer": "^1.0.10",
     "js-yaml": "^3.12.0"
   }
 }

--- a/packages/syntax/src/index.ts
+++ b/packages/syntax/src/index.ts
@@ -1,4 +1,4 @@
-import { Lexer, LexerRules } from '@marklet/core'
+import { Lexer, LexerContexts } from '@marklet/lexer'
 
 type SyntaxRule = SyntaxMetaRule | SyntaxIncludeRule | SyntaxRegexRule
 interface SyntaxToken { scope: string, text: string }
@@ -48,6 +48,6 @@ export class SyntaxLexer extends Lexer {
       })
     }
     for (const key in contexts) traverse(contexts[key])
-    super(<LexerRules>contexts, { macros })
+    super(contexts as LexerContexts, { macros })
   }
 }

--- a/packages/syntax/tsconfig.json
+++ b/packages/syntax/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [
     "src"
   ],

--- a/packages/syntax/tsconfig.json
+++ b/packages/syntax/tsconfig.json
@@ -8,6 +8,6 @@
     "rootDir": "src"
   },
   "references": [
-    { "path": "../core" }
+    { "path": "../lexer" }
   ]
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marklet/test",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "author": "jjyyxx <1449843302@qq.com>",
   "homepage": "https://github.com/obstudio/Marklet",
@@ -17,6 +17,6 @@
   },
   "dependencies": {
     "@marklet/detok": "^1.0.4",
-    "markletjs": "^1.1.4"
+    "markletjs": "^1.1.13"
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "target": "es2018",
+    "noImplicitAny": true,
+    "composite": true,
+    "esModuleInterop": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "./packages/core" },
     { "path": "./packages/dev-server" },
     { "path": "./packages/detok" },
+    { "path": "./packages/inline" },
     { "path": "./packages/parser" },
     { "path": "./packages/syntax" }
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,4 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "declaration": true,
-    "target": "es2018",
-    "noImplicitAny": true,
-    "composite": true,
-    "esModuleInterop": true
-  },
   "references": [
     { "path": "./packages/core" },
     { "path": "./packages/dev-server" },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "./packages/dev-server" },
     { "path": "./packages/detok" },
     { "path": "./packages/inline" },
+    { "path": "./packages/lexer" },
     { "path": "./packages/parser" },
     { "path": "./packages/syntax" }
   ],


### PR DESCRIPTION
重构了部分 Lexer 逻辑，具体如下：
- 将 InlineLexer 从 core 中独立出来，作为`@marklet/inline`
- InlineLexer 和 Lexer 共用的部分将作为新的`@marklet/core`，原来的 core 变为`@marklet/lexer`
- 取消了 getter 属性，对应逻辑直接内置在 InlineLexer 中，使用 #3 建议的方式处理
- Lexer 上下文中除了支持过去的`LexerRule[]`以外，现在允许直接使用 InlineLexer 实例了
- RegexRule 新增属性`strict`，当设为`true`时且内部的状态遇到无匹配的情形是，会自动 pop

目前有关能否 include 一个 InlineLexerInstance 的问题我还在考虑，程序中涉及的部分目前使用了一种比较 hack 的解决方案：
https://github.com/obstudio/Marklet/blob/inline-lexer/packages/lexer/src/index.ts#L70-L78