### PR TITLE
Menu refactor

### DIFF
--- a/packages/dev-server/comp/app.vue
+++ b/packages/dev-server/comp/app.vue
@@ -208,7 +208,7 @@ module.exports = {
       }
     },
     startDrag(position, event) {
-      this.$menuManager.hideContextMenus()
+      this.$menuManager.hideAllMenus()
       this.dragging = position
       this.$refs[position].classList.add('active')
       this.draggingLastX = event.clientX
@@ -220,7 +220,7 @@ module.exports = {
 
 <template>
   <div :class="[theme, { dragging }]" class="marklet">
-    <ob-menubar class="menubar" menu="menubar"/>
+    <ob-menubar class="menubar" from="menubar"/>
     <div class="view explorer" :style="explorerStyle"/>
     <div class="border left" ref="left" :style="leftBorderStyle"
       @mousedown.stop="startDrag('left', $event)"/>

--- a/packages/dev-server/comp/menu/index.js
+++ b/packages/dev-server/comp/menu/index.js
@@ -14,7 +14,7 @@ module.exports = function(Vue) {
   Vue.component('ob-menubar', menubar)
 
   let $menuManager = null
-  const commandData = {}, menuData = {}
+  const commandData = {}
   const MenuManager = Vue.extend(manager)
 
   Vue.prototype.$registerCommands = function(commands) {
@@ -30,41 +30,25 @@ module.exports = function(Vue) {
     })
   }
 
-  Vue.prototype.$registerMenus = function(menus, parentNode) {
-    menus.forEach(function walk(menu) {
-      if (menu.ref) {
-        menuData[menu.ref] = menu
-        menuData[menu.ref].show = false
-        menuData[menu.ref].focused = false
-        menuData[menu.ref].current = null
-      }
-      if (menu.children) {
-        menu.children.forEach(walk)
-      }
-    })
+  Vue.prototype.$registerMenus = function(menu) {
     const element = document.createElement('div')
     
-    $menuManager = new MenuManager({ propsData: { menuData } })
+    $menuManager = new MenuManager({ propsData: { menu } })
     $menuManager.$context = this
-    $menuManager._commands = commandData
+    $menuManager.commands = commandData
     Vue.prototype.$menuManager = $menuManager
 
-    function mountMenu() {
-      $menuManager.$mount((parentNode || this.$el).appendChild(element))
+    function mountMenuManager() {
+      $menuManager.$mount(this.$el.appendChild(element))
 
-      this.$el.addEventListener('click', () => {
-        $menuManager.hideContextMenus()
-      })
-  
-      this.$el.addEventListener('contextmenu', () => {
-        $menuManager.hideContextMenus()
-      })
+      this.$el.addEventListener('click', () => $menuManager.hideAllMenus())
+      this.$el.addEventListener('contextmenu', () => $menuManager.hideAllMenus())
     }
 
     if (this._isMounted) {
-      mountMenu()
+      mountMenuManager()
     } else {
-      this.$options.mounted.push(mountMenu)
+      this.$options.mounted.push(mountMenuManager)
     }
   }
 }

--- a/packages/dev-server/comp/menu/index.js
+++ b/packages/dev-server/comp/menu/index.js
@@ -19,6 +19,7 @@ module.exports = function(Vue) {
 
   Vue.prototype.$registerCommands = function(commands) {
     commands.forEach((command) => {
+      command.context = this
       const key = command.key ? command.key : toKebab(command.method)
       commandData[key] = command
       if (!command.bind || command.bind.startsWith('!')) return
@@ -30,11 +31,10 @@ module.exports = function(Vue) {
     })
   }
 
-  Vue.prototype.$registerMenus = function(menu) {
+  Vue.prototype.$initializeMenu = function() {
     const element = document.createElement('div')
     
-    $menuManager = new MenuManager({ propsData: { menu } })
-    $menuManager.$context = this
+    $menuManager = new MenuManager()
     $menuManager.commands = commandData
     Vue.prototype.$menuManager = $menuManager
 
@@ -50,5 +50,11 @@ module.exports = function(Vue) {
     } else {
       this.$options.mounted.push(mountMenuManager)
     }
+  }
+
+  Vue.prototype.$registerMenus = function(menu) {
+    if (!$menuManager) this.$initializeMenu()
+
+    $menuManager.register(this, menu)
   }
 }

--- a/packages/dev-server/comp/menu/manager.vue
+++ b/packages/dev-server/comp/menu/manager.vue
@@ -1,11 +1,12 @@
 <script>
 
-module.exports = {
-  props: ['menuData'],
+const util = require('./util')
+const menuView = require('./menu-view.vue')
 
-  components: {
-    MenuView: require('./menu-view.vue'),
-  },
+module.exports = {
+  components: { menuView },
+
+  props: ['menu'],
 
   data: () => ({
     loaded: false,
@@ -13,7 +14,13 @@ module.exports = {
 
   computed: {
     refs() {
-      return this.$refs.map(ref => ref instanceof Array ? ref[0] : ref)
+      const result = {}
+      this.menu.forEach((item, index) => {
+        if (item.ref) {
+          result[item.ref] = this.$refs.main.$refs[index][0]
+        }
+      })
+      return result
     },
   },
 
@@ -48,7 +55,7 @@ module.exports = {
         return arg
       }
     },
-    hideContextMenus() {
+    hideAllMenus() {
       for (const key in this.menuData) {
         this.menuData[key].show = false
         this.menuData[key].current = null
@@ -56,48 +63,16 @@ module.exports = {
     },
     showContextMenu(key, event) {
       const style = this.$refs[key][0].$el.style
-      this.hideContextMenus()
-      this.locateMenuAtClient(event, style)
+      this.hideAllMenus()
+      util.locateAtMouseEvent(event, style)
       this.menuData[key].show = true
-    },
-    locateMenuAtClient(event, style) {
-      if (event.clientX + 200 > innerWidth) {
-        style.left = event.clientX - 200 - this.left + 'px'
-      } else {
-        style.left = event.clientX - this.left + 'px'
-      }
-      if (event.clientY - this.top > this.height / 2) {
-        style.top = ''
-        style.bottom = this.top + this.height - event.clientY + 'px'
-      } else {
-        style.top = event.clientY - this.top + 'px'
-        style.bottom = ''
-      }
     },
     showButtonMenu(key, event) {
       const style = this.$refs[key][0].$el.style
       const rect = event.currentTarget.getBoundingClientRect()
-      this.hideContextMenus()
-      this.locateAtTopBottom(rect, style)
+      this.hideAllMenus()
+      util.locateAtTopBottom(rect, style)
       this.menuData[key].show = true
-    },
-    locateAtTopBottom(rect, style) {
-      if (rect.left + 200 > innerWidth) {
-        style.left = rect.left + rect.width - 200 + 'px'
-      } else {
-        style.left = rect.left + 'px'
-      }
-      style.top = rect.top + rect.height + 'px'
-    },
-    locateAtLeftRight(rect, style) {
-      if (rect.right + 200 > innerWidth) {
-        style.left = null
-        style.right = rect.left + 'px'
-      } else {
-        style.right = null
-        style.left = rect.right + 'px'
-      }
-      style.top = rect.top + 'px'
     },
   }
 }
@@ -105,47 +80,16 @@ module.exports = {
 </script>
 
 <template>
-  <div class="marklet-menu-manager">
-    <transition name="marklet-menu" v-for="(menu, key) in menuData" :key="key">
-      <menu-view class="marklet-menu" v-show="menu.show" :data="menu" :ref="key"/>
-    </transition>
-  </div>
+  <menu-view ref="main" :menu="menu"/>
 </template>
 
 <style lang="scss" scoped>
 
 & {
-  width: 0;
-  height: 0;
   top: 0;
   left: 0;
-}
-
-.marklet-menu {
-  z-index: 10;
-  padding: 0;
-  margin: 0;
-  outline: 0;
-  border: none;
-  padding: 2px 0;
-  position: absolute;
-  transition: 0.3s ease;
-}
-
-.marklet-menu-enter-active,
-.marklet-menu-leave-active {
-  opacity: 1;
-  transform: scaleY(1);
-  transform-origin: center top;
-  transition:
-    transform 0.3s cubic-bezier(0.23, 1, 0.32, 1),
-    opacity 0.3s cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.marklet-menu-enter,
-.marklet-menu-leave-to {
-  opacity: 0;
-  transform: scaleY(0);
+  width: 0;
+  height: 0;
 }
 
 </style>

--- a/packages/dev-server/comp/menu/menu-item.vue
+++ b/packages/dev-server/comp/menu/menu-item.vue
@@ -18,12 +18,15 @@ module.exports = {
       type: String,
       default: '',
     },
+    context: {
+      type: Object
+    },
   },
 
   computed: {
     disabled() {
       if (!this.command.enabled) return
-      return !this.$menuManager.parseArgument(this.command.enabled)
+      return !this.$menuManager.parseArgument(this.command.enabled, this.context)
     },
     keybinding() {
       let binding = this.binding || this.command.bind
@@ -52,7 +55,7 @@ module.exports = {
   <div :class="['menu-item', { disabled }]" @click="handleClick">
     <span class="label">
       <mkl-checkbox v-if="command.checked !== undefined"
-        :value="$menuManager.parseArgument(command.checked)" @change="handleClick"/>
+        :value="$menuManager.parseArgument(command.checked, context)" @change="handleClick"/>
       {{ caption || command.name }}
       <template v-if="mnemonic"> ({{ mnemonic }})</template>
       <template v-if="command.ellipsis"> ...</template>

--- a/packages/dev-server/comp/menu/menu-view.vue
+++ b/packages/dev-server/comp/menu/menu-view.vue
@@ -1,17 +1,39 @@
 <script>
 
+const util = require('./util')
+const menuItem = require('./menu-item.vue')
+
 module.exports = {
   name: 'menu-view',
-  props: ['data'],
-  components: {
-    MenuItem: require('./menu-item.vue'),
+
+  components: { menuItem },
+
+  props: {
+    menu: Object,
+  },
+
+  data: () => ({
+    active: false,
+    current: null,
+    focused: false,
+  }),
+
+  watch: {
+    show(value) {
+      this.focused = value
+    },
+    current(value) {
+      if (value !== null) {
+        this.$refs[value].active = true
+      }
+    },
   },
 
   mounted() {
     addEventListener('keypress', (event) => {
-      if (!!this.data.show || !this.data.focused) return
+      if (!this.show) return
       const key = event.key.toUpperCase()
-      const index = this.data.children.findIndex(menu => menu.mnemonic === key)
+      const index = this.menu.findIndex(menu => menu.mnemonic === key)
       if (index >= 0) {
         this.toggleMenuItem(index)
       }
@@ -20,7 +42,7 @@ module.exports = {
 
   methods: {
     toggleMenuItem(index) {
-      const item = this.data.children[index]
+      const item = this.menu[index]
       if (typeof item !== 'object') return
       if (item.ref) {
         this.enterMenuItem()
@@ -30,18 +52,18 @@ module.exports = {
         }
       }
     },
-    enterMenuItem(key, index) {
-      const style = this.$menuManager.$refs[key][0].$el.style
-      const rect = this.$el.children[index].getBoundingClientRect()
-      this.$menuManager.locateAtLeftRight(rect, style)
-      this.$menuManager.menuData[key].show = true
+    enterMenuItem(index) {
+      const style = this.$refs[index][0].$el.style
+      const button = this.$refs.body.children[index]
+      util.locateAtLeftRight(style, button)
+      this.$refs[index][0].active = true
     },
-    leaveMenuItem(key, event) {
+    leaveMenuItem(index, event) {
       const x = event.clientX
       const y = event.clientY
       const rect = this.$el.getBoundingClientRect()
       if (x >= rect.left && x <= rect.right && y >= rect.left && y <= rect.right) {
-        this.$menuManager.menuData[key].show = false
+        this.$refs[index][0].active = false
       }
     },
   },
@@ -50,34 +72,60 @@ module.exports = {
 </script>
 
 <template>
-  <div :class="{ focused: data.focused }">
-    <template v-for="(item, index) in data.children">
-      <div :key="index" v-if="item === '@separator'" class="menu-item disabled" @click.stop>
-        <div class="separator"/>
-      </div>
-      <menu-item :key="index" v-else-if="item.ref"
-        @click.native.stop binding=">"
-        :caption="item.caption" :mnemonic="item.mnemonic"
-        @mouseenter.native="enterMenuItem(item.ref, index)"
-        @mouseleave.native="leaveMenuItem(item.ref, $event)"/>
-      <menu-view :key="index" v-else-if="item.children"
-        v-show="data.current === index" :data="item"/>
-      <menu-item :key="index" v-else-if="item.command"
-        :command="$menuManager._commands[item.command]" :mnemonic="item.mnemonic"/>
-      <transition-group :key="index" v-else name="ob-menu-list">
-        <menu-item v-for="(sub, index) in $menuManager.parseArgument(item.data)" :key="index"
-          :class="{ active: sub.key === $menuManager.parseArgument(item.current) }"
-          @click.native="$menuManager.executeMethod(item.switch, sub.key)" :caption="sub.name"/>
-      </transition-group>
-    </template>
+  <!-- eslint-disable -->
+  <div class="marklet-menu" :class="{ active }">
+    <span ref="body" v-show="active && current === null || $parent.active">
+      <template v-for="(item, index) in menu">
+        <!-- submenu -->
+        <menu-item :key="index" v-if="item.children"
+          @click.native.stop binding=">"
+          :caption="item.caption" :mnemonic="item.mnemonic"
+          @mouseenter.native="enterMenuItem(index, $event)"
+          @mouseleave.native="leaveMenuItem(index, $event)"/>
+
+        <!-- command -->
+        <menu-item :key="index" v-else-if="item.command"
+          :command="$menuManager.commands[item.command]" :mnemonic="item.mnemonic"/>
+        
+        <!-- list -->
+        <transition-group :key="index" v-else-if="item.switch" name="ob-menu-list">
+          <menu-item v-for="(sub, index) in $menuManager.parseArgument(item.data)" :key="index"
+            :class="{ active: sub.key === $menuManager.parseArgument(item.current) }"
+            @click.native="$menuManager.executeMethod(item.switch, sub.key)" :caption="sub.name"/>
+        </transition-group>
+
+        <!-- caption -->
+        <div :key="index" v-else class="menu-item disabled" @click.stop>
+          <div v-if="item.caption === '-'" class="separator"/>
+          <div v-else class="caption">{{ item.caption }}</div>
+        </div>
+      </template>
+    </span>
+
+    <!-- children -->
+    <menu-view v-for="(item, index) in menu" v-if="item.children" :key="index"
+      :menu="item.children" :ref="index" v-show="!active || current === index"/>
   </div>
 </template>
 
 <style lang="scss" scoped>
 
 & {
+  position: relative;
+}
+
+&.active {
+  z-index: 10;
+  padding: 0;
+  margin: 0;
+  outline: 0;
+  border: none;
+  padding: 2px 0;
   min-width: 200px;
   user-select: none;
+  width: max-content;
+  position: absolute;
+  transition: 0.3s ease;
 }
 
 .menu-item {
@@ -123,5 +171,20 @@ module.exports = {
   }
 }
 
-</style>
+.ob-menu-enter-active,
+.ob-menu-leave-active {
+  opacity: 1;
+  transform: scaleY(1);
+  transform-origin: center top;
+  transition:
+    transform 0.3s cubic-bezier(0.23, 1, 0.32, 1),
+    opacity 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+}
 
+.ob-menu-enter,
+.ob-menu-leave-to {
+  opacity: 0;
+  transform: scaleY(0);
+}
+
+</style>

--- a/packages/dev-server/comp/menu/menubar.vue
+++ b/packages/dev-server/comp/menu/menubar.vue
@@ -11,13 +11,15 @@ module.exports = {
   },
 
   data: () => ({
-    current: null,
     focused: false,
   }),
 
   computed: {
     children() {
       return this.$menuManager.menu.find(item => item.ref === this.from).children
+    },
+    source() {
+      return this.$menuManager.refs[this.from]
     },
   },
 
@@ -41,25 +43,26 @@ module.exports = {
 
   methods: {
     hoverMenu(index) {
-      const current = this.current
+      const current = this.source.current
       if (current !== null && current !== index) {
         this.toggleMenu(index)
       }
     },
     toggleMenu(index) {
-      if (this.current === index) {
-        this.current = null
+      if (this.source.current === index) {
+        this.source.active = false
+        this.source.current = null
         return
       }
       this.focused = false
-      const source = this.$menuManager.refs[this.from]
-      const style = source.$el.style
+      const style = this.source.$el.style
       const rect = this.$el.children[index].getBoundingClientRect()
       this.$menuManager.hideAllMenus()
       util.locateAtTopBottom(rect, style)
-      source.active = true
-      source.current = index
-      this.current = index
+      this.source.current = index
+      if (!this.source.active) {
+        this.$nextTick(() => this.source.active = true)
+      }
     },
   }
 }
@@ -71,7 +74,7 @@ module.exports = {
     <template v-if="$menuManager.loaded">
       <div v-for="(menu, index) in children" :key="index" class="item"
         @click.stop="toggleMenu(index)" @mouseover.stop="hoverMenu(index)"
-        :class="{ active: current === index }" @contextmenu.stop>
+        :class="{ active: source.current === index }" @contextmenu.stop>
         {{ menu.caption }} (<span class="mnemonic">{{ menu.mnemonic }}</span>)&nbsp;
       </div>
     </template>

--- a/packages/dev-server/comp/menu/util.js
+++ b/packages/dev-server/comp/menu/util.js
@@ -1,0 +1,40 @@
+function locateAtTopBottom(rect, style) {
+  if (rect.left + 200 > innerWidth) {
+    style.left = rect.left + rect.width - 200 + 'px'
+  } else {
+    style.left = rect.left + 'px'
+  }
+  style.top = rect.top + rect.height + 'px'
+}
+
+function locateAtLeftRight(style, ref) {
+  if (ref.offsetRight + 200 > innerWidth) {
+    style.left = null
+    style.right = ref.offsetLeft + 'px'
+  } else {
+    style.right = null
+    style.left = ref.offsetLeft + ref.offsetWidth + 'px'
+  }
+  style.top = ref.offsetTop + 'px'
+}
+
+function locateAtMouseEvent(event, style) {
+  if (event.clientX + 200 > innerWidth) {
+    style.left = event.clientX - 200 + 'px'
+  } else {
+    style.left = event.clientX + 'px'
+  }
+  if (event.clientY > innerHeight / 2) {
+    style.top = ''
+    style.bottom = innerHeight - event.clientY + 'px'
+  } else {
+    style.top = event.clientY + 'px'
+    style.bottom = ''
+  }
+}
+
+module.exports = {
+  locateAtLeftRight,
+  locateAtTopBottom,
+  locateAtMouseEvent,
+}

--- a/packages/dev-server/comp/menus.json
+++ b/packages/dev-server/comp/menus.json
@@ -6,7 +6,7 @@
       "mnemonic": "F",
       "children": [
         { "command": "open-file", "mnemonic": "O" },
-        "@separator",
+        { "caption": "-" },
         { "command": "save", "mnemonic": "S" },
         { "command": "save-as", "mnemonic": "A" },
         { "command": "save-all", "mnemonic": "L" }
@@ -18,11 +18,11 @@
       "children": [
         { "command": "undo", "mnemonic": "U" },
         { "command": "redo", "mnemonic": "R" },
-        "@separator",
+        { "caption": "-" },
         { "command": "cut", "mnemonic": "T" },
         { "command": "copy", "mnemonic": "C" },
         { "command": "paste", "mnemonic": "P" },
-        "@separator",
+        { "caption": "-" },
         { "command": "find", "mnemonic": "F" },
         { "command": "find-next" },
         { "command": "find-previous" }
@@ -35,11 +35,10 @@
         { "command": "trigger-explorer", "mnemonic": "R" },
         { "command": "trigger-editor", "mnemonic": "E" },
         { "command": "trigger-document", "mnemonic": "D" },
-        "@separator",
+        { "caption": "-" },
         { "command": "command-palette", "mnemonic": "C" },
-        "@separator",
+        { "caption": "-" },
         {
-          "ref": "themes",
           "caption": "主题",
           "mnemonic": "T",
           "children": [

--- a/packages/dev-server/themes/dark.scss
+++ b/packages/dev-server/themes/dark.scss
@@ -24,7 +24,7 @@ $active-color: #acdeff;
   &:hover, &.active { background-color: #999999 }
 }
 
-.marklet-menu {
+.marklet-menu.active {
   background-color: $menu-bgcolor;
   box-shadow: 0 2px 8px $menu-shadow;
 

--- a/packages/dev-server/themes/simple.scss
+++ b/packages/dev-server/themes/simple.scss
@@ -24,7 +24,7 @@ $active-color: #409eff;
   &:hover, &.active { background-color: #aaaaaa }
 }
 
-.marklet-menu {
+.marklet-menu > .menu-body {
   background-color: $menu-bgcolor;
   box-shadow: 0 2px 8px $menu-shadow;
 

--- a/packages/dev-server/themes/simple.scss
+++ b/packages/dev-server/themes/simple.scss
@@ -24,7 +24,7 @@ $active-color: #409eff;
   &:hover, &.active { background-color: #aaaaaa }
 }
 
-.marklet-menu > .menu-body {
+.marklet-menu.active {
   background-color: $menu-bgcolor;
   box-shadow: 0 2px 8px $menu-shadow;
 


### PR DESCRIPTION
这个是有点纠结的，简单说一下区别吧。

**原来分支中 menu 的实现是将菜单树全部压平，然后根据需要显示其中的一部分。**

**新分支中的 menu 的实现是仍然将菜单树渲染成树状结构，无论要显示的是树状结构中的哪一个分支。**

新分支的优点：
- 加强了同类 menu 在逻辑上的联系，如果以后要加入 menu 切换的动画会有帮助
- 过去分支中的 menubar 和其他 menu 使用了较为不同的处理方式，而新分支更为统一

新分支的缺点：
- 逻辑更加复杂，且树状渲染会导致数据访问更加的困难，且在复杂情况下的行为更难以把握

除此以外，新分支增加了下面的特性：
- $registerCommands 和 $registerMenus 现在支持多次调用，并会绑定至各自的调用环境进行处理

例如：在 vm1 时调用 $registerCommands，在 vm2 内再次调用 $registerCommands，在 vm3 中调用 $registerMenus，则对应菜单上的命令会自动回到 vm1 和 vm2 中进行调用。

